### PR TITLE
slash and burn for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,8 @@
   </head>
   <body data-spy="scroll" data-target=".site-navbar-target" data-offset="300">
   <div class="site-wrap">
-
+<!-- Blake -->
+    
     <div class="site-mobile-menu site-navbar-target">
       <div class="site-mobile-menu-header">
         <div class="site-mobile-menu-close mt-3">
@@ -93,28 +94,15 @@
                 Come to enjoy the unabashed <a href="https://www.visitbuffaloniagara.com/9-classic-buffalo-foods-to-be-thankful-for/" target="_blank">comfort foods</a> and the
                 killer <a href="https://www.visitbuffaloniagara.com/business-type/breweries-distilleries/" target="_blank">craft beers</a>. We are offering to share a best-kept
                 secret with our Code4Lib colleagues.</p>
-              <!--  <p><a href="#" target="_blank" class="btn btn-outline-primary btn-md">Button</a></p> -->
+ <p><small>Image credits:<a href="https://commons.wikimedia.org/wiki/File:McKinley_Monument,_Buffalo,_NY_-_IMG_3702.JPG" target="_blank"> McKinley Monument in Niagara Square, Buffalo, New York</a> by <a href="https://commons.wikimedia.org/wiki/Category:Files_uploaded_by_Daderot" target="_blank">Daderot</a>. Public domain<br />
+    Keep Buffalo a Secret, mural by Ian de Beer. Photograph by Chris Hollister. Used with permission. </small></p>               
+              <p>Website design uses components from <a href="https://colorlib.com" target="_blank" >Colorlib</a>, shared through CC-BY-3.0 license.</p>
               </div>
             </div>
           </div>
         </div>
       </div>
     </div> <!-- END .site-blocks-cover -->
-    <p><small>Image credits:<a href="https://commons.wikimedia.org/wiki/File:McKinley_Monument,_Buffalo,_NY_-_IMG_3702.JPG" target="_blank"> McKinley Monument in Niagara Square, Buffalo, New York</a> by <a href="https://commons.wikimedia.org/wiki/Category:Files_uploaded_by_Daderot" target="_blank">Daderot</a>. Public domain<br />
-    Keep Buffalo a Secret, mural by Ian de Beer. Photograph by Chris Hollister. Used with permission. </small></p>
-    <footer class="site-footer">
-      <div class="container">
-        <div class="row mt-1 mb-1 text-center">
-          <div class="col-md-12">
-              <!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. -->
-              <small style="color:#ccc">Website design uses components from <a href="https://colorlib.com" target="_blank" >Colorlib</a>, shared through CC-BY-3.0 license.
-            <!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. -->
-          </small>
-          </div>
-
-        </div>
-      </div>
-    </footer>
   </div>
 
   <script src="js/jquery-3.3.1.min.js"></script>


### PR DESCRIPTION
This moves the credits and footer into the area below the text. It works on mobile and real monitors too. Looks... well, different. Better or worse, you decide.